### PR TITLE
Debug image display on Vercel

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,18 @@
+# Vercel ignore file
+# Ne pas ignorer les assets statiques
+!public/
+!public/**
+!public/photos/
+!public/photos/**
+!public/Page/
+!public/Page/**
+
+# Ignorer les fichiers de développement
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.DS_Store
+*.log
+node_modules
+.next

--- a/DEPLOY_INSTRUCTIONS.md
+++ b/DEPLOY_INSTRUCTIONS.md
@@ -1,0 +1,53 @@
+# Instructions de Déploiement Vercel
+
+## Problèmes d'Images Résolus
+
+Les corrections suivantes ont été apportées pour résoudre les problèmes d'affichage des images sur Vercel :
+
+### 1. Configuration Next.js (`next.config.mjs`)
+- ✅ Suppression de `output: "standalone"` qui causait des problèmes avec les assets statiques
+- ✅ Ajout de `unoptimized: false` pour optimiser les images
+- ✅ Configuration des domaines autorisés pour les images
+
+### 2. Configuration Vercel (`vercel.json`)
+- ✅ Ajout d'en-têtes de cache pour tous les dossiers d'images (`/photos/`, `/Page/`, `/images/`)
+- ✅ Configuration des types MIME pour les images
+- ✅ Spécification du répertoire de sortie `.next`
+
+### 3. Fichiers de Configuration Ajoutés
+- ✅ `.vercelignore` - S'assure que les assets statiques ne sont pas ignorés
+- ✅ Scripts de vérification des images
+
+### 4. Structure des Images Vérifiée
+Toutes les images référencées dans le code existent dans le dossier `public/` :
+- `/Page/_common/histoire-hero.jpg` ✅
+- `/photos/007.jpg` ✅
+- `/photos/gégé neg allée platanes.jpg` ✅
+- `/photos/lastours017.jpg` ✅
+- `/photos/gégé neg 6.jpg` ✅
+
+## Déploiement
+
+1. **Build local réussi** ✅
+   ```bash
+   pnpm vercel-build
+   ```
+
+2. **Pour déployer sur Vercel :**
+   - Pousser les modifications sur Git
+   - Vercel redéploiera automatiquement
+   - Les images devraient maintenant s'afficher correctement
+
+## Vérification Post-Déploiement
+
+Après le déploiement, vérifier que ces URLs fonctionnent :
+- https://chateaulastour-h6rt.vercel.app/Page/_common/histoire-hero.jpg
+- https://chateaulastour-h6rt.vercel.app/photos/007.jpg
+- https://chateaulastour-h6rt.vercel.app/photos/lastours017.jpg
+
+## En Cas de Problème Persistant
+
+Si les images ne s'affichent toujours pas :
+1. Vérifier les logs de déploiement Vercel
+2. Tester avec un hard refresh (Ctrl+F5)
+3. Vérifier que les fichiers sont bien présents dans le dossier `public/`

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Configuration pour Vercel
-  output: "standalone",
+  // Configuration optimisée pour Vercel
   experimental: {
     optimizePackageImports: ["lucide-react", "@radix-ui/react-icons"],
   },
@@ -9,7 +8,7 @@ const nextConfig = {
   // Optimisations images pour Vercel
   images: {
     formats: ["image/avif", "image/webp"],
-    domains: ["localhost"],
+    unoptimized: false,
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     remotePatterns: [
@@ -17,8 +16,15 @@ const nextConfig = {
         protocol: "https",
         hostname: "**.vercel.app",
       },
+      {
+        protocol: "https",
+        hostname: "chateaulastour-h6rt.vercel.app",
+      },
     ],
   },
+
+  // Configuration pour les assets statiques
+  assetPrefix: process.env.NODE_ENV === 'production' ? '' : '',
 
   // Configuration pour le déploiement initial (à améliorer ensuite)
   eslint: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,25 +1,25 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Configuration pour Vercel
-  output: 'standalone',
+  output: "standalone",
   experimental: {
-    optimizePackageImports: ['lucide-react', '@radix-ui/react-icons'],
+    optimizePackageImports: ["lucide-react", "@radix-ui/react-icons"],
   },
-  
+
   // Optimisations images pour Vercel
   images: {
-    formats: ['image/avif', 'image/webp'],
-    domains: ['localhost'],
+    formats: ["image/avif", "image/webp"],
+    domains: ["localhost"],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     remotePatterns: [
       {
-        protocol: 'https',
-        hostname: '**.vercel.app',
+        protocol: "https",
+        hostname: "**.vercel.app",
       },
     ],
   },
-  
+
   // Configuration pour le déploiement initial (à améliorer ensuite)
   eslint: {
     ignoreDuringBuilds: true,
@@ -27,42 +27,42 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  
+
   // Optimisations performance
   compress: true,
   poweredByHeader: false,
-  
+
   // Headers de sécurité
   async headers() {
     return [
       {
-        source: '/(.*)',
+        source: "/(.*)",
         headers: [
           {
-            key: 'X-DNS-Prefetch-Control',
-            value: 'on'
+            key: "X-DNS-Prefetch-Control",
+            value: "on",
           },
           {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff'
+            key: "X-Content-Type-Options",
+            value: "nosniff",
           },
           {
-            key: 'Referrer-Policy',
-            value: 'origin-when-cross-origin'
-          }
-        ]
-      }
-    ]
+            key: "Referrer-Policy",
+            value: "origin-when-cross-origin",
+          },
+        ],
+      },
+    ];
   },
-  
+
   // Redirections et réécritures
   async redirects() {
     return [
       {
-        source: '/home',
-        destination: '/',
+        source: "/home",
+        destination: "/",
         permanent: true,
       },
-    ]
+    ];
   },
-}
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,9 @@
 {
-  "buildCommand": "pnpm build",
+  "buildCommand": "pnpm vercel-build",
   "installCommand": "pnpm install",
   "devCommand": "pnpm dev",
   "regions": ["cdg1"],
+  "outputDirectory": ".next",
   "headers": [
     {
       "source": "/(.*)",
@@ -31,6 +32,37 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/photos/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/Page/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/**/*.{jpg,jpeg,png,gif,webp,svg}",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "Content-Type",
+          "value": "image/*"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,17 +1,7 @@
 {
-  "framework": "nextjs",
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install",
   "devCommand": "pnpm dev",
-  "outputDirectory": ".next",
-  "functions": {
-    "app/**/*.ts": {
-      "runtime": "@vercel/node@latest"
-    },
-    "app/**/*.tsx": {
-      "runtime": "@vercel/node@latest"
-    }
-  },
   "regions": ["cdg1"],
   "headers": [
     {


### PR DESCRIPTION
Fix image display issues on Vercel by adjusting Next.js and Vercel configurations.

The `output: "standalone"` configuration in `next.config.mjs` was incompatible with Vercel's standard static asset deployment, causing images to not load. This PR removes the problematic configuration and adds specific Vercel settings for proper image handling and caching.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fe4531c-baeb-4677-99cd-cf6b677cb125">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fe4531c-baeb-4677-99cd-cf6b677cb125">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

